### PR TITLE
哈里发翻译修正

### DIFF
--- a/translations/website/start/1.12/po/zh_CN.po
+++ b/translations/website/start/1.12/po/zh_CN.po
@@ -261,10 +261,10 @@ msgid ""
 "be more expensive than those of the Loyalist faction, they make up for this "
 "with high mobility — especially on hilly terrains."
 msgstr ""
-"这个版本能见到在多人游戏中玩家可玩的新派系——哈里发。您可以在游戏中选用“默认"
-"+哈里发”时代，这个派系的子民缺乏魔法师，而擅长于利用地形在黎明或者黄昏发起进"
+"这个版本能见到在多人游戏中玩家可玩的新派系——沙漠。您可以在游戏中选用“默认"
+"+沙漠”时代，这个派系的子民缺乏魔法师，而擅长于利用地形在黎明或者黄昏发起进"
 "攻。他们的兵种有守序和边缘单位，治疗者、高命中率的肉搏型战士，可怕的骑兵型射"
-"手。哈里发单位常常比保皇军队更贵，不过有更高的机动性来平衡——尤其在丘陵地形。"
+"手。沙漠单位常常比保皇军队更贵，不过有更高的机动性来平衡——尤其在丘陵地形。"
 
 #. type: Content of: <html><body><div><div><p>
 #: template.html:91

--- a/translations/wesnoth/po/wesnoth-help/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-help/zh_CN.po
@@ -3852,15 +3852,15 @@ msgstr ""
 
 #. [race]: id=khalifate
 msgid "race^Khalifate Human"
-msgstr "哈里发"
+msgstr "沙漠"
 
 #. [race]: id=khalifate
 msgid "race+female^Khalifate Human"
-msgstr "哈里发"
+msgstr "沙漠"
 
 #. [race]: id=khalifate
 msgid "race+plural^Khalifate"
-msgstr "哈里发"
+msgstr "沙漠"
 
 #. [race]: id=khalifate
 msgid "This race does not have a description yet."

--- a/translations/wesnoth/po/wesnoth-multiplayer/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-multiplayer/zh_CN.po
@@ -79,7 +79,7 @@ msgstr ""
 
 #. [era]: id=era_khalifate
 msgid "Default + Khalifate"
-msgstr "默认 + 哈里发"
+msgstr "默认 + 沙漠"
 
 #. [era]: id=era_khalifate
 msgid ""
@@ -90,14 +90,14 @@ msgid ""
 "This era is still under development, so please be sure to report any "
 "problems that arise."
 msgstr ""
-"此时代中除了默认时代的六大派系之外，还含有一个额外的派系。哈里发单位不使用魔"
+"此时代中除了默认时代的六大派系之外，还含有一个额外的派系。沙漠单位不使用魔"
 "法，而是依赖于对地形的谨慎利用和晨昏时段的协同攻击。\n"
 "\n"
 "此时代仍在开发中，因此请务必报告出现的一切问题。"
 
 #. [era]: id=era_khalifate_heroes
 msgid "Age of Heroes + Khalifate"
-msgstr "英雄时代 + 哈里发"
+msgstr "英雄时代 + 沙漠"
 
 #. [era]: id=era_khalifate_heroes
 msgid ""
@@ -108,7 +108,7 @@ msgid ""
 "This era is still under development, so please be sure to report any "
 "problems that arise."
 msgstr ""
-"此时代中除了英雄时代的六大派系之外，还含有一个额外的派系。哈里发单位不使用魔"
+"此时代中除了英雄时代的六大派系之外，还含有一个额外的派系。沙漠单位不使用魔"
 "法，而是依赖于对地形的谨慎利用和晨昏时段的协同攻击。\n"
 "\n"
 "此时代仍在开发中，因此请务必报告出现的一切问题。"
@@ -119,7 +119,7 @@ msgstr "龙人部落"
 
 #. [multiplayer_side]: id=Khalifate, type=random
 msgid "Khalifate"
-msgstr "哈里发"
+msgstr "沙漠"
 
 #. [multiplayer_side]: id=Knalgan Alliance, type=random
 msgid "Knalgan Alliance"

--- a/translations/wesnoth/po/wesnoth-units/zh_CN.po
+++ b/translations/wesnoth/po/wesnoth-units/zh_CN.po
@@ -2613,7 +2613,7 @@ msgstr ""
 
 #. [unit_type]: id=Arif, race=khalifate
 msgid "Arif"
-msgstr "阿里夫"
+msgstr "沙漠步兵"
 
 #. [unit_type]: id=Arif, race=khalifate
 msgid ""
@@ -2624,9 +2624,9 @@ msgid ""
 "troops to exploit. The sight of Arif on the march, shields high, has caused "
 "many a defender to worry about the strength of their walls."
 msgstr ""
-"阿里夫是哈里发步兵中的骨干。他们大多来自贵族或者军事家庭，并且花费了大半辈子"
+"沙漠步兵是沙漠士兵中的骨干。他们大多来自贵族或者军事家庭，并且花费了大半辈子"
 "修习武艺。因为他们高超的剑技，他们常被派去负责攻坚战，为其余部队打开突破口。"
-"当看到阿里夫高举着盾牌进军时，守军们常常不禁担忧起他们的城墙是否足够坚固。"
+"当看到沙漠步兵高举着盾牌进军时，守军们常常不禁担忧起他们的城墙是否足够坚固。"
 
 #. [attack]: type=blade
 msgid "long sword"
@@ -2634,7 +2634,7 @@ msgstr "长剑"
 
 #. [unit_type]: id=Batal, race=khalifate
 msgid "Batal"
-msgstr "巴塔尔"
+msgstr "沙漠游侠"
 
 #. [unit_type]: id=Batal, race=khalifate
 msgid ""
@@ -2645,7 +2645,7 @@ msgid ""
 "taking on only the most daring missions, Batal are often heroes to the "
 "common troopers, an image they do not try to dissuade."
 msgstr ""
-"巴塔尔是穆哈里卜中的精英，善于采用不间断的游击战术侵扰敌军。他们迅捷如风，勇"
+"沙漠游侠是沙漠斥候中的精英，善于采用不间断的游击战术侵扰敌军。他们迅捷如风，勇"
 "猛如虎，能够协调一致地同时发动多重打击。以弓箭驱赶敌人，再以战斧将他们砍倒。"
 "Batal热衷于接受最勇敢的任务，因此总被军人们视为英雄，他们也有意识地维护着这样"
 "的形象。"
@@ -2689,7 +2689,7 @@ msgstr ""
 
 #. [unit_type]: id=Faris, race=khalifate
 msgid "Faris"
-msgstr "法里斯"
+msgstr "沙漠骑士"
 
 #. [unit_type]: id=Faris, race=khalifate
 msgid ""
@@ -2699,13 +2699,13 @@ msgid ""
 "rest of the Khalifate cavalry. Consummate horsemen, the Faris have long "
 "claimed they need only a single lance strike to kill a man."
 msgstr ""
-"那些在战斗中脱颖而出的哈伊亚被给予机会在试炼中证明自己，通过试炼者就成了法里"
-"斯。它们被授予传统的马铠，这使他们在哈里发骑兵中与众不同。法里斯堪称完美的骑"
+"那些在战斗中脱颖而出的沙漠骑手被给予机会在试炼中证明自己，通过试炼者就成了法里"
+"斯。它们被授予传统的马铠，这使他们在沙漠骑兵中与众不同。沙漠骑士堪称完美的骑"
 "兵，他们一直宣称毙敌只需要一击长枪就够了。"
 
 #. [unit_type]: id=Ghazi, race=khalifate
 msgid "Ghazi"
-msgstr "加齐"
+msgstr "沙漠武者"
 
 #. [unit_type]: id=Ghazi, race=khalifate
 msgid ""
@@ -2715,8 +2715,8 @@ msgid ""
 "in number, their presence can be decisive in dislodging even the most "
 "hardened redoubt."
 msgstr ""
-"加齐们在哈里发军中小有名望，他们是以剑盾和信仰作为武装的战士。他们精进了自己"
-"的战斗技巧，在格斗中加入了强力的盾击以击倒无备之敌。尽管加齐人数稀少，但只要"
+"沙漠武者们在沙漠军中小有名望，他们是以剑盾和信仰作为武装的战士。他们精进了自己"
+"的战斗技巧，在格斗中加入了强力的盾击以击倒无备之敌。尽管沙漠武者人数稀少，但只要"
 "他们出手，再难攻的碉堡也不再话下。"
 
 #. [attack]: type=impact
@@ -2725,7 +2725,7 @@ msgstr "盾击"
 
 #. [unit_type]: id=Hadaf, race=khalifate
 msgid "Hadaf"
-msgstr "哈达夫"
+msgstr "沙漠侦骑"
 
 #. [unit_type]: id=Hadaf, race=khalifate
 msgid ""
@@ -2735,13 +2735,13 @@ msgid ""
 "a time, returning to camp only for supplies and to pass on news of their "
 "exploits."
 msgstr ""
-"那些在战斗中表现出高超技巧的卡纳斯们被编入了哈达夫的行列，他们被用来洗劫敌人"
+"那些在战斗中表现出高超技巧的沙漠哨骑们被编入了沙漠侦骑的行列，他们被用来洗劫敌人"
 "的仓库与城镇以谋取给养。更大的自主权常常意味着这些骑兵们常常一出征就是数周，"
 "仅仅为了补给物资和报告功绩才返回营地。"
 
 #. [unit_type]: id=Hakim, race=khalifate
 msgid "Hakim"
-msgstr "哈基姆"
+msgstr "沙漠信徒"
 
 #. [unit_type]: id=Hakim, race=khalifate
 msgid ""
@@ -2753,14 +2753,14 @@ msgid ""
 "possess a potent clutch of medicines and herbs, which allows them to quickly "
 "heal even the most gravely wounded allies."
 msgstr ""
-"哈基姆是哈里发中的博学者，他们为了协助出征的军队放弃了自己的市民生活。个中的"
+"沙漠信徒是沙漠中的博学者，他们为了协助出征的军队放弃了自己的市民生活。个中的"
 "动机有许多，有的人追求冒险或一份稳定的收入，而另一些人则受到了信仰的感召。无"
-"论如何，哈基姆们受到所有人的高度敬仰。他们受过深入的医术训练，并且手握丰富的"
+"论如何，沙漠信徒们受到所有人的高度敬仰。他们受过深入的医术训练，并且手握丰富的"
 "药材资源，因此即使是受伤最严重的士兵也能被他们快速治愈。"
 
 #. [unit_type]: id=Jawal, race=khalifate
 msgid "Jawal"
-msgstr "贾瓦尔"
+msgstr "沙漠精骑"
 
 #. [unit_type]: id=Jawal, race=khalifate
 msgid ""
@@ -2771,14 +2771,14 @@ msgid ""
 "with great speed through the lines of battle to rain arrows down upon the "
 "enemy."
 msgstr ""
-"萨里中的精锐就是贾瓦尔，他们是兼具那样高超的速度与灵活性的骑射手，以致于流言"
+"沙漠迅骑中的精锐就是沙漠精骑，他们是兼具那样高超的速度与灵活性的骑射手，以致于流言"
 "总说他们身上流淌着精灵之血。也许是被这种带有神秘感的无稽之谈激怒了吧，Jawal在"
 "战斗中总是跻身前线，展示高超的战斗技巧。如疾风般穿行在战线间，将矢雨浇在敌人"
 "的身上。"
 
 #. [unit_type]: id=Jundi, race=khalifate
 msgid "Jundi"
-msgstr "骏迪"
+msgstr "沙漠蛮兵"
 
 #. [unit_type]: id=Jundi, race=khalifate
 msgid ""
@@ -2789,13 +2789,13 @@ msgid ""
 "fight best at dawn or dusk, corresponding to the time when desert "
 "temperatures are the most reasonable."
 msgstr ""
-"在许多方面，骏迪都是哈里发单位的理想代表：灵活，机动，攻守兼备，远近全能。他"
+"在许多方面，沙漠蛮兵都是沙漠单位的理想代表：灵活，机动，攻守兼备，远近全能。他"
 "们习于在南方的沙漠和山丘中进行作战，那正是他们最熟悉的地形与环境。此外，他们"
 "最擅长在清晨或者傍晚战斗，因为在沙漠中那是温度最合适的时间。"
 
 #. [unit_type]: id=Khaiyal, race=khalifate
 msgid "Khaiyal"
-msgstr "哈伊亚"
+msgstr "沙漠骑手"
 
 #. [unit_type]: id=Khaiyal, race=khalifate
 msgid ""
@@ -2806,14 +2806,14 @@ msgid ""
 "Khaiyal ride into the resulting melee with their maces in hand, trusting "
 "their armor to keep them safe."
 msgstr ""
-"哈伊亚明白冲锋的马匹对敌军心理上的冲击，并通过身着重甲来增强这种震撼感。傲立"
-"时魁梧威严，持矛冲锋的哈伊亚所携的冲击则常常足以令敌人散架。在极少数哈伊亚的"
+"沙漠骑手明白冲锋的马匹对敌军心理上的冲击，并通过身着重甲来增强这种震撼感。傲立"
+"时魁梧威严，持矛冲锋的沙漠骑手所携的冲击则常常足以令敌人散架。在极少数沙漠骑手的"
 "冲锋没能击溃敌人的情境中，他们会纵马迎敌持锤而战，信赖身上的铁铠能保障自己的"
 "安全。"
 
 #. [unit_type]: id=Khalid, race=khalifate
 msgid "Khalid"
-msgstr "哈立德"
+msgstr "沙漠武师"
 
 #. [unit_type]: id=Khalid, race=khalifate
 msgid ""
@@ -2825,12 +2825,12 @@ msgid ""
 "living legends."
 msgstr ""
 "在每代人里总会涌现出一位超越所有同辈与敌人的卓越武士，他们看上去能够仅凭一己"
-"之力改变世界的命运。这些武士以虔诚和武技著称，常常被冠上古老的传奇领袖哈立德"
+"之力改变世界的命运。这些武士以虔诚和武技著称，常常被冠上古老的传奇领袖沙漠武师"
 "的尊名。他们的游历与磨难被人以崇拜的口吻在篝火旁不绝传颂。"
 
 #. [unit_type]: id=Mighwar, race=khalifate
 msgid "Mighwar"
-msgstr "密瓦尔"
+msgstr "沙漠剑士"
 
 #. [unit_type]: id=Mighwar, race=khalifate
 msgid ""
@@ -2840,12 +2840,12 @@ msgid ""
 "through the ranks of the enemy, swords ripping and tearing at those around "
 "them. "
 msgstr ""
-"密瓦尔进阶自摩那韦什，他们始终以更高的标准要求自己。密瓦尔不满足于仅仅牵制住"
+"沙漠剑士进阶自沙漠剑客，他们始终以更高的标准要求自己。沙漠剑士不满足于仅仅牵制住"
 "敌人，他们将速度与倾略性相结合，在敌阵中跳起令人血肉横飞的剑舞。"
 
 #. [unit_type]: id=Monawish, race=khalifate
 msgid "Monawish"
-msgstr "摩那韦什"
+msgstr "沙漠剑客"
 
 #. [unit_type]: id=Monawish, race=khalifate
 msgid ""
@@ -2855,13 +2855,13 @@ msgid ""
 "used to harry the flanks of opposing forces, and it is said to be easier to "
 "catch the wind in your hand than to catch a Monawish."
 msgstr ""
-"那些拥有熟练侦查技巧的骏迪被提拔进了摩那韦什的行列。摩那韦什放弃了弓术，专心"
+"那些拥有熟练侦查技巧的沙漠蛮兵被提拔进了沙漠剑客的行列。沙漠剑客放弃了弓术，专心"
 "训练出迅捷的脚力，借此灵活的在战斗中迎敌和脱出。他们主要被派来包抄敌军的侧"
-"翼，而且人们常说捉捕摩那韦什的难度甚于捉风。"
+"翼，而且人们常说捉捕沙漠剑客的难度甚于捉风。"
 
 #. [unit_type]: id=Mudafi, race=khalifate
 msgid "Mudafi"
-msgstr "穆达菲"
+msgstr "沙漠勇者"
 
 #. [unit_type]: id=Mudafi, race=khalifate
 msgid ""
@@ -2871,13 +2871,13 @@ msgid ""
 "preferred strategy is to gradually wear down enemies, until they can be "
 "defeated in a vicious counter stroke."
 msgstr ""
-"尽管哈里发的军队以他们惊人的移动力和猛烈的攻击力而著称，他们也能成为干练的防"
-"守者。穆达菲们擅于固守阵线，用尖利的长矛让敌人无法近身。他们喜好的策略是把敌"
+"尽管沙漠的军队以他们惊人的移动力和猛烈的攻击力而著称，他们也能成为干练的防"
+"守者。沙漠勇者们擅于固守阵线，用尖利的长矛让敌人无法近身。他们喜好的策略是把敌"
 "人耗到筋疲力竭，再以犀利的反击解决战斗。"
 
 #. [unit_type]: id=Mufariq, race=khalifate
 msgid "Mufariq"
-msgstr "穆法里克"
+msgstr "沙漠重骑"
 
 #. [unit_type]: id=Mufariq, race=khalifate
 msgid ""
@@ -2888,14 +2888,14 @@ msgid ""
 "riders in the slightest, and the displaced air of a descending mace is the "
 "last sound they hear."
 msgstr ""
-"穆法里克是杰出的骑手，积攒着如同他们铠甲上的漩涡纹饰那般别致耀眼的头衔和赞"
-"誉。长年的战斗让穆法里克磨练出了一手使枪的绝技，这让他们成为了一只不可阻挡的"
+"沙漠重骑是杰出的骑手，积攒着如同他们铠甲上的漩涡纹饰那般别致耀眼的头衔和赞"
+"誉。长年的战斗让沙漠重骑磨练出了一手使枪的绝技，这让他们成为了一只不可阻挡的"
 "力量。逃窜的敌人们很快就发现山丘丝毫不能对这些骑手构成障碍，然后便在铁锤的破"
 "风声中被结果了性命。"
 
 #. [unit_type]: id=Muharib, race=khalifate
 msgid "Muharib"
-msgstr "穆哈里卜"
+msgstr "沙漠斥候"
 
 #. [unit_type]: id=Muharib, race=khalifate
 msgid ""
@@ -2905,13 +2905,13 @@ msgid ""
 "issue pilfering these supplies, and so they tend to be more well-equipped "
 "than most."
 msgstr ""
-"穆哈里卜常被用作重型的侦察兵。他们不再仅仅侦查敌人，还会洗劫敌人的补给线或者"
-"歼灭敌人的巡逻队。因为常常长时间待在敌后，穆哈里卜毫不介意窃取敌人的物资，因"
+"沙漠斥候常被用作重型的侦察兵。他们不再仅仅侦查敌人，还会洗劫敌人的补给线或者"
+"歼灭敌人的巡逻队。因为常常长时间待在敌后，沙漠斥候毫不介意窃取敌人的物资，因"
 "此他们常常拥有比大多数人更好的装备。"
 
 #. [unit_type]: id=Naffat, race=khalifate
 msgid "Naffat"
-msgstr "纳法掷油兵"
+msgstr "沙漠掷焰手"
 
 #. [unit_type]: id=Naffat, race=khalifate
 msgid ""
@@ -2920,7 +2920,7 @@ msgid ""
 "the use of fire in warfare is not a novel concept, the flames of the Naffat "
 "have proven disturbingly difficult for their enemies to extinguish."
 msgstr ""
-"纳法掷油兵是哈里发军中的必要之恶，他们用火焰去烧毁敌人的堡垒，在敌人中间散播"
+"沙漠掷焰手是沙漠军中的必要之恶，他们用火焰去烧毁敌人的堡垒，在敌人中间散播"
 "恐惧。虽然把火焰用于战争这个概念早已不再新奇，但是掷油兵的敌人们总是会发现他"
 "们的火焰异常的恼人和难对付。"
 
@@ -2934,7 +2934,7 @@ msgstr "火焰箭"
 
 #. [unit_type]: id=Qanas, race=khalifate
 msgid "Qanas"
-msgstr "卡纳斯"
+msgstr "沙漠哨骑"
 
 #. [unit_type]: id=Qanas, race=khalifate
 msgid ""
@@ -2945,14 +2945,14 @@ msgid ""
 "needed. Qanas are often used to draw enemies into a position where they will "
 "be surrounded and crushed by Faris."
 msgstr ""
-"那些既不足以凭借技巧加入法里斯的集团又不具备萨里集团所必须的迅捷与弓术的骑兵"
-"就会被编入卡纳斯的行列。这并不意味着他们就是失败者，恰恰相反，卡纳斯被创造为"
-"马背上的穆哈里卜，能够视需要以铁锤或弓箭为步兵提供辅助。卡纳斯常被用来将敌人"
-"诱入法里斯的包围网，然后让法里斯们来将敌人碾碎。"
+"那些既不足以凭借技巧加入沙漠骑士的集团又不具备沙漠迅骑集团所必须的迅捷与弓术的骑兵"
+"就会被编入沙漠哨骑的行列。这并不意味着他们就是失败者，恰恰相反，沙漠哨骑被创造为"
+"马背上的沙漠斥候，能够视需要以铁锤或弓箭为步兵提供辅助。沙漠哨骑常被用来将敌人"
+"诱入沙漠骑士的包围网，然后让沙漠骑士们来将敌人碾碎。"
 
 #. [unit_type]: id=Qatif_al_nar, race=khalifate
 msgid "Qatif-al-nar"
-msgstr "卡提夫-阿尔-纳尔"
+msgstr "沙漠举火者"
 
 #. [unit_type]: id=Qatif_al_nar, race=khalifate
 msgid ""
@@ -2961,13 +2961,13 @@ msgid ""
 "troops, Qatif-al-nar can be easily located in battle by the cleared charred "
 "area around them, a testament to the success of their experiments."
 msgstr ""
-"卡提夫-阿尔-纳尔花费了太多时间试验他们的武器，以致于他们身上一直散发着一股灰"
+"沙漠举火者花费了太多时间试验他们的武器，以致于他们身上一直散发着一股灰"
 "烬和火焰的味道。他们总被同袍们以谨慎的眼光看待。根据战场上的焦土痕迹，人们很"
 "容易就能在战场上确定他们的位置。那是对他们成功实验的有力宣言。"
 
 #. [unit_type]: id=Rami, race=khalifate
 msgid "Rami"
-msgstr "拉米"
+msgstr "沙漠轻骑"
 
 #. [unit_type]: id=Rami, race=khalifate
 msgid ""
@@ -2976,13 +2976,13 @@ msgid ""
 "superior speed and agility to circle and harass their foes, whittling down "
 "their numbers with relentless arrows."
 msgstr ""
-"拉米是优秀的骑兵，他们在马背上射箭能够比许多人站在地上射得还准。拉米不愿使用"
+"沙漠轻骑是优秀的骑兵，他们在马背上射箭能够比许多人站在地上射得还准。沙漠轻骑不愿使用"
 "重甲，他们利用自己的高速和灵活去包围和不断骚扰敌人，用无情的箭雨削减敌人的数"
 "量。"
 
 #. [unit_type]: id=Rasikh, race=khalifate
 msgid "Rasikh"
-msgstr "拉什赫"
+msgstr "沙漠勇士"
 
 #. [unit_type]: id=Rasikh, race=khalifate
 msgid ""
@@ -2993,14 +2993,14 @@ msgid ""
 "they can be trusted to hold any position or line, long after lesser soldiers "
 "and men have fled in terror."
 msgstr ""
-"哈里发的土地上分布着孤立的高塔与要塞，它们负责为商队和当地居民提供防护，以抵"
+"沙漠的土地上分布着孤立的高塔与要塞，它们负责为商队和当地居民提供防护，以抵"
 "御盗贼和怪物的袭扰。意志最坚定的士兵们负责这些堡垒的守卫，他们为了抵御入侵者"
 "常常不得不在压倒性的逆境中作战。在军队中，他们是最值得信赖的战线守卫者。即使"
 "友军们早已在恐惧中溃逃，他们仍然能够坚守住自己的位置。"
 
 #. [unit_type]: id=Saree, race=khalifate
 msgid "Saree"
-msgstr "萨里"
+msgstr "沙漠迅骑"
 
 #. [unit_type]: id=Saree, race=khalifate
 msgid ""
@@ -3009,13 +3009,13 @@ msgid ""
 "This has made them the fastest riders in the Khalifate armies, and a wise "
 "Khalid uses this to their advantage."
 msgstr ""
-"那些展现出了高人一等的弓术的拉米会被编入萨里的集团。他们每天会花费许多个小时"
-"用来练习，以和胯下的坐骑建立默契。这让萨里成为了哈里发军队中最迅捷的骑手。在"
-"一位睿智的哈立德帐下受驱使时，他们能够尽情发挥这方面长处。"
+"那些展现出了高人一等的弓术的沙漠轻骑会被编入沙漠迅骑的集团。他们每天会花费许多个小时"
+"用来练习，以和胯下的坐骑建立默契。这让沙漠迅骑成为了沙漠军队中最迅捷的骑手。在"
+"一位睿智的沙漠武师帐下受驱使时，他们能够尽情发挥这方面长处。"
 
 #. [unit_type]: id=Shuja, race=khalifate
 msgid "Shuja"
-msgstr "舒贾"
+msgstr "沙漠武士"
 
 #. [unit_type]: id=Shuja, race=khalifate
 msgid ""
@@ -3024,13 +3024,13 @@ msgid ""
 "soldiers to fight for their cause. Despite this, they are often found "
 "leading from the front, taking down their foes with sword and shield."
 msgstr ""
-"舒贾们因为勇气和技巧而受众人仰慕，他们是哈里发军阶体系中的领导者。他们的光辉"
+"沙漠武士们因为勇气和技巧而受众人仰慕，他们是沙漠军阶体系中的领导者。他们的光辉"
 "事迹广为同袍们所熟知，激励着士兵们为他们卖命。尽管如此，他们仍然常常在作战时"
 "身先士卒，以剑盾击倒他们的敌人。"
 
 #. [unit_type]: id=Tabib, race=khalifate
 msgid "Tabib"
-msgstr "塔比卜"
+msgstr "沙漠祭司"
 
 #. [unit_type]: id=Tabib, race=khalifate
 msgid ""
@@ -3040,13 +3040,13 @@ msgid ""
 "well, often to the disbelief of the injured. Hardened by years of travels, "
 "many are able to treat themselves."
 msgstr ""
-"有的人像别人专长于力量那样精于医术，而塔比卜对于医药的知识在哈里发外无人能"
+"有的人像别人专长于力量那样精于医术，而沙漠祭司对于医药的知识在沙漠外无人能"
 "及。他们的药物不仅能够治愈伤口，还能消除感染和解毒。其药效之神奇往往让伤者感"
 "到难以置信。他们中的许多人因长年的旅行而变得坚韧，能够处理好自身的伤病。"
 
 #. [unit_type]: id=Tineen, race=khalifate
 msgid "Tineen"
-msgstr "提宁"
+msgstr "沙漠焚天士"
 
 #. [unit_type]: id=Tineen, race=khalifate
 msgid ""
@@ -3055,8 +3055,8 @@ msgid ""
 "of the value of life, Tineen are caught up in the power of their caged fire "
 "and likely to test their latest naphtha jar at the first opportunity."
 msgstr ""
-"那些排除了世俗之扰，完全投身进自己的实验的卡提夫-阿尔-纳尔被人用敬语称作提"
-"宁，这个名字同时带有尊敬与恐惧之意。提宁们已不再意识到生命的价值，他们被笼中"
+"那些排除了世俗之扰，完全投身进自己的实验的沙漠举火者被人用敬语称作提"
+"宁，这个名字同时带有尊敬与恐惧之意。沙漠焚天士们已不再意识到生命的价值，他们被笼中"
 "火焰的力量所迷摄，不愿放过任何一个测试他们最新式燃烧罐的机会。"
 
 #. [unit_type]: id=Mermaid Diviner, race=merman


### PR DESCRIPTION
将“哈里发”派系翻译修正为“沙漠”派系，相关兵种名称也进行了修正。

修改文件列表：
\translations\website\start\1.12\po\zh_CN.po
\translations\wesnoth\po\wesnoth-help\zh_CN.po
\translations\wesnoth\po\wesnoth-multiplayer\zh_CN.po
\translations\wesnoth\po\wesnoth-units\zh_CN.po